### PR TITLE
skip wildcard routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function snapshot(app) {
 
 function routes(app) {
   return app._router.stack.filter(function (layer) {
-    if (layer.route && ~layer.route.path.indexOf(':')) {
+    if (layer.route && (~layer.route.path.indexOf(':') || ~layer.route.path.indexOf('*'))) {
       console.log('skipping', layer.route.path);
     } else {
       return layer.route;


### PR DESCRIPTION
Thanks for creating this tool, I just used it to convert one of my old projects into a github pages site.

It's common for express apps to use a wildcard route like this, which express-snapshot doesn't like:
```
app.get('*', function(req, res){
  res.render('404');
});
```

